### PR TITLE
Fix the bug exposed by Time_7 fault localization 

### DIFF
--- a/FaultLocalization/src/main/java/edu/lu/uni/serval/dataprepare/DataPreparer.java
+++ b/FaultLocalization/src/main/java/edu/lu/uni/serval/dataprepare/DataPreparer.java
@@ -20,6 +20,8 @@ public class DataPreparer {
 
     private String buggyProjectParentPath;
     
+    public String bugDir; // the working directory for GZoltar.
+    
     public String classPath;
     public String srcPath;
     public String testClassPath;
@@ -62,6 +64,8 @@ public class DataPreparer {
 		srcPath = projectDir + buggyProject + paths.get(2);
 		testSrcPath = projectDir + buggyProject + paths.get(3);
 
+		bugDir = projectDir + buggyProject; // set bugDir.
+		
 		List<File> libPackages = new ArrayList<>();// dependencies.
 		if (new File(projectDir + buggyProject + "/lib/").exists()) {
 			libPaths.add(projectDir + buggyProject + "/lib/");

--- a/FaultLocalization/src/main/java/edu/lu/uni/serval/faultlocalization/FL.java
+++ b/FaultLocalization/src/main/java/edu/lu/uni/serval/faultlocalization/FL.java
@@ -36,7 +36,9 @@ public class FL {
 	public static void main(String[] args) {
 		String outputPath = "GZoltar-0.1.1/" + Configuration.SUSPICIOUS_POSITIONS_FILE_APTH;
 		String path = Configuration.BUGGY_PROJECTS_PATH;
-		String projectName = "Chart_11";
+		
+		// To run FL for Time_7.
+		String projectName = "Time_7";
 		
 		log.info(projectName);
 		
@@ -73,7 +75,7 @@ public class FL {
 		gzfl.srcPath = path + buggyProject + PathUtils.getSrcPath(buggyProject).get(2);
 		
 		try {
-			gzfl.localizeSuspiciousCodeWithGZoltar(dp.classPaths, checkNotNull(Arrays.asList("")), dp.testCases);
+			gzfl.localizeSuspiciousCodeWithGZoltar(dp.bugDir, dp.classPaths, checkNotNull(Arrays.asList("")), dp.testCases);
 		} catch (NullPointerException e) {
 			for (String metricStr : Configuration.METRICS_0_1_1) {
 				FileHelper.outputToFile(outputPath + buggyProject + "/" + metricStr + ".txt", "", false);
@@ -136,7 +138,7 @@ public class FL {
 		gzfl.srcPath = path + buggyProject + PathUtils.getSrcPath(buggyProject).get(2);
 		
 		try {
-			gzfl.localizeSuspiciousCodeWithGZoltar(dp.classPaths, checkNotNull(Arrays.asList("")), dp.testCases);
+			gzfl.localizeSuspiciousCodeWithGZoltar(dp.bugDir, dp.classPaths, checkNotNull(Arrays.asList("")), dp.testCases);
 		} catch (NullPointerException e) {
 			log.error(buggyProject + "\n" + e.getMessage());
 			e.printStackTrace();

--- a/FaultLocalization/src/main/java/edu/lu/uni/serval/faultlocalization/GZoltarFaultLoclaization.java
+++ b/FaultLocalization/src/main/java/edu/lu/uni/serval/faultlocalization/GZoltarFaultLoclaization.java
@@ -47,7 +47,7 @@ public class GZoltarFaultLoclaization {
 	public List<String> failingTestCases = new ArrayList<String>();
 	public ArrayList<Statement> selectedSuspiciousStatements = new ArrayList<>();
 	
-	public void localizeSuspiciousCodeWithGZoltar(final URL[] clazzPaths, Collection<String> packageNames, String... testClasses) throws NullPointerException {
+	public void localizeSuspiciousCodeWithGZoltar(String bugDir, final URL[] clazzPaths, Collection<String> packageNames, String... testClasses) throws NullPointerException {
 		ArrayList<String> classPaths = new ArrayList<String>();
 		StringBuilder b = new StringBuilder();
         for (URL url : clazzPaths) {// Dependencies. lib
@@ -65,7 +65,13 @@ public class GZoltarFaultLoclaization {
         b.setLength(0);
         
         try {
-			GZoltar gzoltar = new GZoltar(System.getProperty("user.dir"));
+        	// Dale:
+        	// the original code: new GZoltar(System.getProperty("user.dir"))
+        	// will lead to unexpected failed test cases when localizing Time buggy projects, 
+        	// (e.g., this leads to the failure of org.joda.time.TestSerialization#testSerializedMutableDateTime when localizing Time_7.
+        	// The failing detail includes: java.io.FileNotFoundException: src/test/resources/MutableDateTime.dat (No such file or directory)
+        	// Therefore, the GZoltar working dir should be the bugDir, rather than the current FL project dir.
+			GZoltar gzoltar = new GZoltar(bugDir);
 			
 			if (classPaths != null && !classPaths.isEmpty()) {
 				gzoltar.getClasspaths().addAll(classPaths);
@@ -277,6 +283,10 @@ public class GZoltarFaultLoclaization {
 //                } else {
 //                	totalFailedTestCases ++;
 //                }
+				
+				// to print the failed tests
+				System.out.println("The failed test case:" + tr.getName() + "  " + tr.wasSuccessful());
+				
 				if (!failingTestCases.contains(testName)) failingTestCases.add(testName);
 			}
 		}


### PR DESCRIPTION
the original code in GZoltarFaultLoclaization.java : 
`new GZoltar(System.getProperty("user.dir"))`
 
will lead to unexpected failed test cases when localizing Time buggy projects,  (e.g., this leads to the failure of `org.joda.time.TestSerialization#testSerializedMutableDateTime` when localizing Time_7.

The failing trace is :

> java.io.FileNotFoundException: **src/test/resources/MutableDateTime.dat (No such file or directory)**
> 	at java.io.FileInputStream.open(Native Method)
> 	at java.io.FileInputStream.<init>(FileInputStream.java:146)
> 	at java.io.FileInputStream.<init>(FileInputStream.java:101)
> 	at org.joda.time.TestSerialization.loadAndCompare(TestSerialization.java:293)
> 	at org.joda.time.TestSerialization.testSerializedMutableDateTime(TestSerialization.java:148)
> 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
> 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 	at java.lang.reflect.Method.invoke(Method.java:606)
> 	at junit.framework.TestCase.runTest(TestCase.java:176)
> 	at junit.framework.TestCase.runBare(TestCase.java:141)
> 	at junit.framework.TestResult$1.protect(TestResult.java:122)
> 	at junit.framework.TestResult.runProtected(TestResult.java:142)
> 	at junit.framework.TestResult.run(TestResult.java:125)
> 	at junit.framework.TestCase.run(TestCase.java:129)
> 	at junit.framework.TestSuite.runTest(TestSuite.java:255)
> 	at junit.framework.TestSuite.run(TestSuite.java:250)
> 	at junit.framework.TestSuite.runTest(TestSuite.java:255)
> 	at junit.framework.TestSuite.run(TestSuite.java:250)
> 	at junit.framework.TestSuite.runTest(TestSuite.java:255)
> 	at junit.framework.TestSuite.run(TestSuite.java:250)
> 	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
> 	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
> 	at org.junit.runner.JUnitCore.run(JUnitCore.java:138)
> 	at com.gzoltar.core.instr.testing.junit.JUnitRunner.run(JUnitRunner.java:47)
> 	at com.gzoltar.core.instr.Runner.main(Runner.java:46)

Based on this, we can know that these unexpected failed tests are caused by incorrect working directory when initializing GZoltar fault localizer.

Therefore, the GZoltar working dir should be the bugDir, rather than the current FL project dir.